### PR TITLE
Definindo o network do docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - 8000:8000
     env_file:
       - ./env.dev
+    networks:
+      - backend
     depends_on:
       - db
   db:
@@ -20,6 +22,11 @@ services:
       - POSTGRES_USER=dev
       - POSTGRES_PASSWORD=dev
       - POSTGRES_DB=escola_db
+    networks:
+      - backend
+networks:
+  backend:
+    driver: bridge
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Definindo o network do docker-compose como brigde :
networks:
  backend:
    driver: bridge

é uma funcionalidade poderosa que permite a criação e o gerenciamento de redes no Docker